### PR TITLE
Bump TensorFlow version to '2.6.2'

### DIFF
--- a/academy/dog-breed-classification/dog-breed-katib.ipynb
+++ b/academy/dog-breed-classification/dog-breed-katib.ipynb
@@ -130,7 +130,7 @@
     "from tensorflow.keras.preprocessing import image\n",
     "from tensorflow.keras.applications import ResNet50\n",
     "from tensorflow.keras.callbacks import ModelCheckpoint\n",
-    "from keras.applications.resnet50 import preprocess_input\n",
+    "from tensorflow.keras.applications.resnet50 import preprocess_input\n",
     "\n",
     "# When LOAD_TRUNCATED_IMAGES is set to True,\n",
     "# loading is permitted but plotting the images\n",

--- a/academy/dog-breed-classification/dog-breed-v2.ipynb
+++ b/academy/dog-breed-classification/dog-breed-v2.ipynb
@@ -343,7 +343,7 @@
    "source": [
     "train_generator = get_train_generator()\n",
     "batch = train_generator.next()\n",
-    "predictions = is_dog(batch)"
+    "predictions = is_dog(batch[0])"
    ]
   },
   {

--- a/academy/dog-breed-classification/dog-breed.ipynb
+++ b/academy/dog-breed-classification/dog-breed.ipynb
@@ -101,6 +101,28 @@
     "tags": []
    },
    "source": [
+    "### Install requirements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!pip3 install --user -r requirements/requirements.txt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
     "### Below is the `imports` cell. This is where we import all the necessary libraries"
    ]
   },
@@ -136,34 +158,12 @@
     "from tensorflow.keras.preprocessing import image\n",
     "from tensorflow.keras.applications import ResNet50\n",
     "from tensorflow.keras.callbacks import ModelCheckpoint\n",
-    "from keras.applications.resnet50 import preprocess_input\n",
+    "from tensorflow.keras.applications.resnet50 import preprocess_input\n",
     "\n",
     "# When LOAD_TRUNCATED_IMAGES is set to True,\n",
     "# loading is permitted but plotting the images\n",
     "# shows only plain black rectangles.\n",
     "ImageFile.LOAD_TRUNCATED_IMAGES = True"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
-    "### Install requirements"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "skip"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "!pip3 install --user -r requirements/requirements.txt"
    ]
   },
   {

--- a/academy/dog-breed-classification/requirements/requirements-v2.txt
+++ b/academy/dog-breed-classification/requirements/requirements-v2.txt
@@ -1,3 +1,3 @@
 pillow==7.2.0
-tensorflow==2.3.0
+tensorflow==2.6.2
 matplotlib==3.3.1

--- a/academy/dog-breed-classification/requirements/requirements.txt
+++ b/academy/dog-breed-classification/requirements/requirements.txt
@@ -1,10 +1,9 @@
-opencv-python-headless
+opencv-python-headless==4.6.0.66
 h5py>=2.10.0
 matplotlib==3.1.3
 numpy>=1.19.5
 scipy==1.4.1
 tqdm==4.11.2
-keras==2.0.2
 scikit-learn==0.23.2
 pillow==6.2.1
-tensorflow==2.2.0
+tensorflow==2.6.2

--- a/academy/openvaccine-kaggle-competition/requirements.txt
+++ b/academy/openvaccine-kaggle-competition/requirements.txt
@@ -1,3 +1,3 @@
 pandas
 requests
-tensorflow==2.3.0
+tensorflow==2.6.2

--- a/academy/openvaccine-kaggle-competition/requirements.txt
+++ b/academy/openvaccine-kaggle-competition/requirements.txt
@@ -1,3 +1,3 @@
-pandas
-requests
+pandas==1.4.2
+requests==2.27.1
 tensorflow==2.6.2


### PR DESCRIPTION
Bump the TensorFlow version to '2.6.2' for the examples that use TensorFlow:

- OpenVaccine
- DogBreed (`v1` & `v1`)

Closes arrikto/dev#2008