### PR TITLE
Revert TF 2.6.2 version bump and dependency changes

### DIFF
--- a/academy/dog-breed-classification/dog-breed-katib.ipynb
+++ b/academy/dog-breed-classification/dog-breed-katib.ipynb
@@ -130,7 +130,7 @@
     "from tensorflow.keras.preprocessing import image\n",
     "from tensorflow.keras.applications import ResNet50\n",
     "from tensorflow.keras.callbacks import ModelCheckpoint\n",
-    "from tensorflow.keras.applications.resnet50 import preprocess_input\n",
+    "from keras.applications.resnet50 import preprocess_input\n",
     "\n",
     "# When LOAD_TRUNCATED_IMAGES is set to True,\n",
     "# loading is permitted but plotting the images\n",

--- a/academy/dog-breed-classification/dog-breed-v2.ipynb
+++ b/academy/dog-breed-classification/dog-breed-v2.ipynb
@@ -343,7 +343,7 @@
    "source": [
     "train_generator = get_train_generator()\n",
     "batch = train_generator.next()\n",
-    "predictions = is_dog(batch[0])"
+    "predictions = is_dog(batch)"
    ]
   },
   {

--- a/academy/dog-breed-classification/dog-breed.ipynb
+++ b/academy/dog-breed-classification/dog-breed.ipynb
@@ -101,28 +101,6 @@
     "tags": []
    },
    "source": [
-    "### Install requirements"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": [
-     "skip"
-    ]
-   },
-   "outputs": [],
-   "source": [
-    "!pip3 install --user -r requirements/requirements.txt"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "tags": []
-   },
-   "source": [
     "### Below is the `imports` cell. This is where we import all the necessary libraries"
    ]
   },
@@ -158,12 +136,34 @@
     "from tensorflow.keras.preprocessing import image\n",
     "from tensorflow.keras.applications import ResNet50\n",
     "from tensorflow.keras.callbacks import ModelCheckpoint\n",
-    "from tensorflow.keras.applications.resnet50 import preprocess_input\n",
+    "from keras.applications.resnet50 import preprocess_input\n",
     "\n",
     "# When LOAD_TRUNCATED_IMAGES is set to True,\n",
     "# loading is permitted but plotting the images\n",
     "# shows only plain black rectangles.\n",
     "ImageFile.LOAD_TRUNCATED_IMAGES = True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "### Install requirements"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "!pip3 install --user -r requirements/requirements.txt"
    ]
   },
   {

--- a/academy/dog-breed-classification/requirements/requirements-v2.txt
+++ b/academy/dog-breed-classification/requirements/requirements-v2.txt
@@ -1,3 +1,3 @@
 pillow==7.2.0
-tensorflow==2.6.2
+tensorflow==2.3.0
 matplotlib==3.3.1

--- a/academy/dog-breed-classification/requirements/requirements.txt
+++ b/academy/dog-breed-classification/requirements/requirements.txt
@@ -1,9 +1,10 @@
-opencv-python-headless==4.6.0.66
+opencv-python-headless
 h5py>=2.10.0
 matplotlib==3.1.3
 numpy>=1.19.5
 scipy==1.4.1
 tqdm==4.11.2
+keras==2.0.2
 scikit-learn==0.23.2
 pillow==6.2.1
-tensorflow==2.6.2
+tensorflow==2.2.0

--- a/academy/openvaccine-kaggle-competition/requirements.txt
+++ b/academy/openvaccine-kaggle-competition/requirements.txt
@@ -1,3 +1,3 @@
-pandas==1.4.2
-requests==2.27.1
-tensorflow==2.6.2
+pandas
+requests
+tensorflow==2.3.0


### PR DESCRIPTION
The recent version bump to TF 2.6.2 and Python 3.8.0 brought along
changes to the dependencies of some of our examples.

In particular, the pin `pandas==1.4.2` in the OpenVaccine example
broke it when attempting to run in containers using Python 3.6.

Revert the recent changes introduced in https://github.com/arrikto/examples/pull/3 to keep on supporting Python 3.6 and
Tensorflow 2.3.0.

This commit reverts the following commits:
1. 707a93e724b34ab7dc0777d66960d975f5cd2701
2. b931efb224f5084f65a007126775aa1b1d1e227f
3. 5d9672000dcfcc16434700ed1c83a89d4a1b728f
4. af3727c38d046bf528388c9cfe23295dffe8706b

Refs arrikto/dev#2032