### PR TITLE
openvaccine: Fix TensorFlow and typing-extensions version

### DIFF
--- a/academy/openvaccine-kaggle-competition/requirements.txt
+++ b/academy/openvaccine-kaggle-competition/requirements.txt
@@ -1,3 +1,4 @@
 pandas==1.4.2
 requests==2.27.1
-tensorflow==2.6.2
+tensorflow==2.3.0
+fastapi==0.78.0


### PR DESCRIPTION
Fix TensorFlow and typing-extensions versions. Specifically:

* Fix TF version to 2.3.0 so Kale can marshal TF models
* Fix `typing-extensions` version to 3.10.0.2 to solve the `ImportError`
  raised by the Transformer component

Refs arrikto/dev#1918
Closes arrikto/dev#2065

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>