### PR TITLE
Remove Kale default docker image tag

### DIFF
--- a/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
+++ b/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
@@ -706,7 +706,7 @@
      "type": "clone"
     }
    ],
-   "docker_image": "gcr.io/arrikto-playground/dimpo/arrikto-cpu@sha256:0e110b0273119cc6eb4e2d28bdd4416fad960c7b34a377e4a298ec85a02f2f96",
+   "docker_image": "",
    "experiment": {
     "id": "new",
     "name": "open-vaccine"

--- a/academy/coronahack-distributed-training/inference.ipynb
+++ b/academy/coronahack-distributed-training/inference.ipynb
@@ -469,7 +469,7 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:5c30d30c0459b0d7597293900be0897d5595a819f5a8311765cd928f87835d44",
+   "docker_image": "",
    "experiment": {
     "id": "",
     "name": ""


### PR DESCRIPTION
Remove the default image so that Kale doesn't show a warning when
compiling the notebook using a workbench with a different image.

Signed-off-by: Stefano Fioravanzo <stefano@arrikto.com>