### PR TITLE
bulldozers: Fix pandas to version 1.1.5

### DIFF
--- a/academy/bulldozers-kaggle-competition/requirements.txt
+++ b/academy/bulldozers-kaggle-competition/requirements.txt
@@ -4,3 +4,4 @@ tensorboardX==2.2
 Pillow==8.2.0
 fastai==2.3.0
 yellowbrick==1.3
+pandas==1.1.5


### PR DESCRIPTION
Fix the version of the Pandas module to 1.1.5 to avoid FutureWarnings.

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>