### PR TITLE
Open images using LANCZOS resambling

### DIFF
--- a/academy/coronahack-distributed-training/inference.ipynb
+++ b/academy/coronahack-distributed-training/inference.ipynb
@@ -101,7 +101,7 @@
    ],
    "source": [
     "img = Image.open(img_path)\n",
-    "img.thumbnail(img_size, Image.ANTIALIAS)\n",
+    "img.thumbnail(img_size, Image.Resampling.LANCZOS)\n",
     "img.show()"
    ]
   },

--- a/academy/coronahack-distributed-training/requirements.txt
+++ b/academy/coronahack-distributed-training/requirements.txt
@@ -1,3 +1,4 @@
 pandas==1.1.5
 torchmetrics==0.5.1
 kaggle==1.5.12
+Pillow==9.2.0


### PR DESCRIPTION
coronahack: Open images using LANCZOS resambling
    
Use the `LANCZOS` resambling technique to load images with PIL, since `ANTIALIAS` is deprecated.

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>