### PR TITLE
Introduce changes in the OpenVaccine example

### DIFF
--- a/academy/openvaccine-kaggle-competition/open-vaccine.ipynb
+++ b/academy/openvaccine-kaggle-competition/open-vaccine.ipynb
@@ -334,30 +334,27 @@
    "outputs": [],
    "source": [
     "def process_features(example):\n",
+    "    import numpy as np\n",
+    "\n",
     "    sequence_sentences = example[0]\n",
     "    structure_sentences = example[1]\n",
     "    loop_sentences = example[2]\n",
     "    \n",
     "    # transform character sequences into number sequences\n",
     "    sequence_tokens = np.array(\n",
-    "        tokenizer.texts_to_sequences(sequence_sentences)\n",
-    "    )\n",
+    "        tokenizer.texts_to_sequences(sequence_sentences))\n",
     "    structure_tokens = np.array(\n",
-    "        tokenizer.texts_to_sequences(structure_sentences)\n",
-    "    )\n",
+    "        tokenizer.texts_to_sequences(structure_sentences))\n",
     "    loop_tokens = np.array(\n",
-    "        tokenizer.texts_to_sequences(loop_sentences)\n",
-    "    )\n",
+    "        tokenizer.texts_to_sequences(loop_sentences))\n",
     "    \n",
     "    # concatenate the tokenized sequences\n",
     "    sequences = np.stack(\n",
     "        (sequence_tokens, structure_tokens, loop_tokens),\n",
-    "        axis=1\n",
-    "    )\n",
+    "        axis=1)\n",
     "    sequences = np.transpose(sequences, (2, 0, 1))\n",
-    "    \n",
+    "   \n",
     "    prepared = sequences.tolist()\n",
-    "    \n",
     "    return prepared[0]"
    ]
   },
@@ -649,6 +646,88 @@
   },
   {
    "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Serve the Model\n",
+    "\n",
+    "We can leverage the Kale `serve` package to create an InferenceService. This\n",
+    "way, we can easily deploy our model to Kubeflow and serve it as a REST API.\n",
+    "\n",
+    "The first step is to create a `preprocess` function that will be used to create\n",
+    "a transformer component for our InferenceService. This function should take\n",
+    "the raw data as input and return the preprocessed data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "def preprocess(inputs):\n",
+    "    res = list()\n",
+    "    for instance in inputs[\"instances\"]:\n",
+    "        res.append(process_features(instance))\n",
+    "    return {**inputs, \"instances\": res}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, we can use the `serve` function provided by Kale to create an\n",
+    "InferenceService. This function takes the model, the preprocess function and\n",
+    "a configuration object as input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "from kale.common.serveutils import serve\n",
+    "\n",
+    "config  = {\"limits\": {\"memory\": \"4Gi\"}}\n",
+    "\n",
+    "server = serve(model, preprocessing_fn=preprocess,\n",
+    "               preprocessing_assets={\"process_features\": process_features,\n",
+    "                                     \"tokenizer\": tokenizer},\n",
+    "               deploy_config=config)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Invoke the InferenceService to get back the predictions."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "tags": [
+     "skip"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "data = json.dumps({\"instances\": unprocessed_x_public_test})\n",
+    "predictions = server.predict(data)\n",
+    "predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {
     "tags": []
    },
@@ -701,7 +780,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -797,7 +876,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.9"
+   "version": "3.8.12"
   }
  },
  "nbformat": 4,

--- a/academy/openvaccine-kaggle-competition/requirements.txt
+++ b/academy/openvaccine-kaggle-competition/requirements.txt
@@ -1,3 +1,4 @@
 pandas==1.4.2
 requests==2.27.1
-tensorflow==2.6.2
+tensorflow==2.6.3
+fastapi==0.84.0


### PR DESCRIPTION
Change the way Kale serves the model, due to the new serving APIs. Specifically, we want to leverage the new way of creating transformer components everywhere. To this end:

* Make the `preprocess_feature` function stand-alone
* Create a new `preprocess` function that calls the `preprocess_feature`
* Use the `preprocess` function as the `preprocessing_fn` argument and add the `process_features` function as an asset

Refs arrikto/dev#1859
Refs arrikto/dev#1889

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>