### PR TITLE
Reconcile Coronahack with the new PyTorch marshaling backend

### DIFF
--- a/academy/coronahack-distributed-training/coronahack.py
+++ b/academy/coronahack-distributed-training/coronahack.py
@@ -31,7 +31,6 @@ import pandas as pd
 import torchmetrics
 import torch.nn as nn
 import torch.optim as optim
-import torchvision.models as models
 import torchvision.transforms as transforms
 
 from typing import Optional, Tuple, NamedTuple
@@ -43,6 +42,8 @@ from torch.utils.data import Dataset, DataLoader
 from kale.sdk import step, pipeline
 from kale.distributed import pytorch
 from kale.types import MarshalData
+
+from network import Net
 
 
 logging.basicConfig(level=logging.INFO)
@@ -271,15 +272,7 @@ def create_model() -> NamedTuple("outputs", [("model", MarshalData),
     Returns:
         model (torch.nn.Module): The model to train.
     """
-    model = models.resnet18(pretrained=True)
-    model.conv1 = nn.Conv2d(1, 64, kernel_size=(7, 7),
-                            stride=(2, 2), padding=(3, 3), bias=False)
-
-    for param in model.parameters():
-        param.requires_grad = False
-
-    features_in = model.fc.in_features
-    model.fc = nn.Linear(features_in, 2)
+    model = Net()
 
     optimizer = optim.Adam(model.parameters(), lr=0.001)
     criterion = nn.CrossEntropyLoss()

--- a/academy/coronahack-distributed-training/inference.ipynb
+++ b/academy/coronahack-distributed-training/inference.ipynb
@@ -208,30 +208,33 @@
     "\n",
     "We are now ready to load the model we've trained using the `coronahack.py` Python script. The model is stored in this location:\n",
     "\n",
-    "`$HOME/.kale.artifacts.dir/model.pt`\n",
+    "`$HOME/.kale.distributed.dir/model.pt`\n",
     "\n",
     "This way, if you want to start a new distributed job from this Notebook server you won't lose the current saved model. This permits you to work iteratively."
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "home = Path.home()\n",
-    "model_path = home/\".kale.artifacts.dir\"/\"model.pt\""
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model = torch.jit.load(model_path)"
-   ]
-  },
+    "cell_type": "code",
+    "execution_count": 7,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "from kale.marshal import load, set_data_dir\n",
+     "\n",
+     "home = Path.home()\n",
+     "model_path = home/\".kale.distributed.dir\"\n",
+     "set_data_dir(str(model_path))"
+    ]
+   },
+   {
+    "cell_type": "code",
+    "execution_count": 8,
+    "metadata": {},
+    "outputs": [],
+    "source": [
+     "model = load(\"model\")"
+    ]
+   },
   {
    "cell_type": "markdown",
    "metadata": {

--- a/academy/coronahack-distributed-training/network.py
+++ b/academy/coronahack-distributed-training/network.py
@@ -1,0 +1,28 @@
+
+# Copyright © 2022 Arrikto Inc.  All Rights Reserved.
+
+"""PyTorch Model Definition.
+
+This script defines a simple PyTorch CNN.
+"""
+
+import torch.nn as nn
+import torchvision.models as models
+
+
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+        self.model = models.resnet18(pretrained=True)
+        self.model.conv1 = nn.Conv2d(
+            1, 64, kernel_size=(7, 7), stride=(2, 2),
+            padding=(3, 3), bias=False)
+        
+        for param in self.model.parameters():
+            param.requires_grad = False
+            
+        features_in = self.model.fc.in_features
+        self.model.fc = nn.Linear(features_in, 2)
+
+    def forward(self, x):
+        return self.model(x)


### PR DESCRIPTION
coronahack: Reconcile Coronack with the new PyTorch marshal backend
    
Introduce changes to the Coronahack example due to the new PyTorch marshaling backend.
    
The PyTorch marshaling backend creates an archive that includes the serialized model's weights and its definition (i.e., the Python module). Thus, it expects the definition of the model to reside in a different Python module than the one defining the KFP so that it can reference it during the serialization process.
    
When it loads the model, it first imports and executes the Python module to create the model object and then loads the weights.
    
Refs arrikto/dev#1752
Refs arrikto/dev#1889
    
Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>