### PR TITLE
bulldozers: Change sklearnserver image and add transformer

### DIFF
--- a/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
+++ b/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
@@ -430,12 +430,13 @@
     "from kale.serve import serve\n",
     "\n",
     "kale_model_artifact_id = <KALE_MODEL_ARTIFACT_ID_PLACEHOLDER>\n",
+    "kale_transformer_artifact_id = <KALE_TRANSFORMER_ARTIFACT_ID_PLACEHOLDER>\n",
     "\n",
     "serve_config = {\"limits\": {\"memory\": \"4Gi\"},\n",
     "                \"annotations\": {\"sidecar.istio.io/inject\": \"false\"},\n",
-    "                \"predictor\": {\"container\": {\"name\": \"container\", \"image\": \"gcr.io/arrikto/kfserving-sklearnserver-arr:v0.6.1-3-gcea2b3f\"}}}\n",
+    "                \"predictor\": {\"container\": {\"name\": \"container\", \"image\": \"gcr.io/arrikto/kserve-sklearnserver-arr:v0.8.0-32-g2ae228dd\"}}}\n",
     "\n",
-    "isvc = serve(name=\"automl-example\", model_id=kale_model_artifact_id, serve_config=serve_config)"
+    "isvc = serve(name=\"automl-example\", model_id=kale_model_artifact_id, transformer_id=kale_transformer_artifact_id, serve_config=serve_config)"
    ],
    "outputs": [],
    "execution_count": null,
@@ -466,7 +467,7 @@
    "cell_type": "code",
    "source": [
     "import json\n",
-    "data = {\"instances\": X_valid[0:3, 0:62].tolist()}\n",
+    "data = {\"instances\": X_valid[0:3].tolist()}\n",
     "res = endpoint.predict(json.dumps(data))\n",
     "print(res)"
    ],


### PR DESCRIPTION
Change our custom sklearnserver image with a new image that uses KServe, since we had a problem with the version of joblib the image uses.

Also, add a transformer to the InferenceService, so the input of the regressors is transformed by their own transformers accordigly.

Closes arrikto/dev#2131

Signed-off-by: Dorothea Kalliora <dorothea@arrikto.com>