### PR TITLE
bulldozers: Fix joblib version to 1.1.0

### DIFF
--- a/academy/bulldozers-kaggle-competition/requirements.txt
+++ b/academy/bulldozers-kaggle-competition/requirements.txt
@@ -5,3 +5,4 @@ Pillow==8.2.0
 fastai==2.3.0
 yellowbrick==1.3
 pandas==1.1.5
+joblib==1.1.0


### PR DESCRIPTION
Pin the version of joblib to 1.1.0 to avoid incompatibilities when serving SKLearn models.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>