### PR TITLE
Change coronahack torchmetrics requirement

### DIFF
--- a/academy/coronahack-distributed-training/requirements.txt
+++ b/academy/coronahack-distributed-training/requirements.txt
@@ -1,4 +1,4 @@
 pandas==1.1.5
-torchmetrics==0.5.1
+torchmetrics[text]==0.5.1
 kaggle==1.5.12
 Pillow==9.2.0


### PR DESCRIPTION
Change `torchmetrics` requirement, in order to take into account the extra requirements needed for using the text modules.

Closes arrikto/dev#2220

Signed-off-by: Dorothea Kalliora <dorothea@arrikto.com>