### PR TITLE
bulldozers: Stop disabling Istio sidecar injection

### DIFF
--- a/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
+++ b/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
@@ -433,7 +433,6 @@
     "kale_transformer_artifact_id = <KALE_TRANSFORMER_ARTIFACT_ID_PLACEHOLDER>\n",
     "\n",
     "serve_config = {\"limits\": {\"memory\": \"4Gi\"},\n",
-    "                \"annotations\": {\"sidecar.istio.io/inject\": \"false\"},\n",
     "                \"predictor\": {\"container\": {\"name\": \"container\", \"image\": \"gcr.io/arrikto/kserve-sklearnserver-arr:v0.8.0-32-g2ae228dd\"}}}\n",
     "\n",
     "isvc = serve(name=\"automl-example\", model_id=kale_model_artifact_id, transformer_id=kale_transformer_artifact_id, serve_config=serve_config)"


### PR DESCRIPTION
Stop adding the annotation to explicitly disable Istio sidecar injection to the InferenceService which serves the model trained during the bulldozer's example.

Signed-off-by: Ilias Katsakioris <elikatsis@arrikto.com>