### PR TITLE
Update the Bulldozers example with the new AutoSklearn version

### DIFF
--- a/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
+++ b/academy/bulldozers-kaggle-competition/blue-book-bulldozers.ipynb
@@ -80,6 +80,7 @@
    "cell_type": "code",
    "source": [
     "df = pd.read_csv(\"data/train.csv\", low_memory=False)\n",
+    "df = df[[\"SalePrice\", \"ProductSize\", \"YearMade\", \"saledate\"]]\n",
     "df.head()"
    ],
    "outputs": [
@@ -160,7 +161,8 @@
    "cell_type": "code",
    "source": [
     "# expand dates\n",
-    "df = core.add_datepart(df, 'saledate')"
+    "df = core.add_datepart(df, 'saledate')\n",
+    "df = df.drop(\"saleElapsed\", axis=1)"
    ],
    "outputs": [],
    "execution_count": 5,
@@ -433,8 +435,7 @@
     "kale_transformer_artifact_id = <KALE_TRANSFORMER_ARTIFACT_ID_PLACEHOLDER>\n",
     "\n",
     "serve_config = {\"limits\": {\"memory\": \"4Gi\"},\n",
-    "                \"annotations\": {\"sidecar.istio.io/inject\": \"false\"},\n",
-    "                \"predictor\": {\"container\": {\"name\": \"container\", \"image\": \"gcr.io/arrikto/kserve-sklearnserver-arr:v0.8.0-32-g2ae228dd\"}}}\n",
+    "                \"annotations\": {\"sidecar.istio.io/inject\": \"false\"}}",
     "\n",
     "isvc = serve(name=\"automl-example\", model_id=kale_model_artifact_id, transformer_id=kale_transformer_artifact_id, serve_config=serve_config)"
    ],

--- a/academy/bulldozers-kaggle-competition/requirements.txt
+++ b/academy/bulldozers-kaggle-competition/requirements.txt
@@ -1,5 +1,5 @@
-scikit-learn==0.23.2
-auto-sklearn==0.12.0
+scikit-learn>=0.24.0,<0.25.0
+auto-sklearn==0.15.0
 tensorboardX==2.2
 Pillow==8.2.0
 fastai==2.3.0

--- a/academy/bulldozers-kaggle-competition/requirements.txt
+++ b/academy/bulldozers-kaggle-competition/requirements.txt
@@ -3,5 +3,4 @@ auto-sklearn==0.15.0
 tensorboardX==2.2
 Pillow==8.2.0
 fastai==2.3.0
-yellowbrick==1.3
 pandas==1.1.5


### PR DESCRIPTION
Update the Bulldozers examples to make it run faster since the new AutoSklearn version Kale uses generates runs that take hours to complete.